### PR TITLE
Motion update handler no longer accesses the UI from another thread

### DIFF
--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -222,15 +222,17 @@ import ImageIO
                 let rm = motionData.attitude.rotationMatrix
                 var userHeading = .pi - atan2(rm.m32, rm.m31)
                 userHeading += .pi/2
-                
-                if panoramaView.panoramaType == .cylindrical {
-                    panoramaView.cameraNode.eulerAngles = SCNVector3Make(0, Float(-userHeading), 0) // Prevent vertical movement in a cylindrical panorama
+
+                DispatchQueue.main.async {
+                    if panoramaView.panoramaType == .cylindrical {
+                        panoramaView.cameraNode.eulerAngles = SCNVector3Make(0, Float(-userHeading), 0) // Prevent vertical movement in a cylindrical panorama
+                    }
+                    else {
+                        // Use quaternions when in spherical mode to prevent gimbal lock
+                        panoramaView.cameraNode.orientation = motionData.orientation()
+                    }
+                    panoramaView.reportMovement(CGFloat(userHeading), panoramaView.xFov.toRadians())
                 }
-                else {
-                    // Use quaternions when in spherical mode to prevent gimbal lock
-                    panoramaView.cameraNode.orientation = motionData.orientation()
-                }
-                panoramaView.reportMovement(CGFloat(userHeading), panoramaView.xFov.toRadians())
             })
         }
     }


### PR DESCRIPTION
Since device motion updates are performed in `opQueue`, it is not safe to read or set ui properties in a handler.
Wrapped this code in DispatchQueue.main.async to resolve MainThreadChecker issues:
![ctpanoramaview swift edited 2018-04-29 15-59-17](https://user-images.githubusercontent.com/2203199/39407053-cab35a88-4bc8-11e8-8971-5018f0575d19.jpg)
![ctpanoramaview swift edited 2018-04-29 15-58-24](https://user-images.githubusercontent.com/2203199/39407054-cad39672-4bc8-11e8-97b9-79d1abe00ae2.jpg)
