### PR TITLE
Apply SwiftLint guidelines to make code cleaner

### DIFF
--- a/CTPanoramaView.xcodeproj/project.pbxproj
+++ b/CTPanoramaView.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 				CF415AA71E55C70F002A98ED /* Frameworks */,
 				CF415AA81E55C70F002A98ED /* Headers */,
 				CF415AA91E55C70F002A98ED /* Resources */,
+				CE460E572095FFB7007AA570 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -210,6 +211,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		CE460E572095FFB7007AA570 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		CF415AA61E55C70F002A98ED /* Sources */ = {

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 				CF415ADB1E55E314002A98ED /* Frameworks */,
 				CF415ADC1E55E314002A98ED /* Resources */,
 				CF415B341E5ACA85002A98ED /* Embed Frameworks */,
+				CE460E562095FE40007AA570 /* ShellScript */,
 			);
 			buildRules = (
 			);

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -218,6 +218,22 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		CE460E562095FE40007AA570 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		CF415ADA1E55E314002A98ED /* Sources */ = {
 			isa = PBXSourcesBuildPhase;

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -18,4 +18,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/Example/Example/AppDelegate.swift
+++ b/Example/Example/AppDelegate.swift
@@ -10,11 +10,5 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
-        return true
-    }
 }

--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -88,7 +88,7 @@
                     </view>
                     <connections>
                         <outlet property="compassView" destination="aFO-BR-VR0" id="vWZ-ar-ghU"/>
-                        <outlet property="pv" destination="C0u-qY-bwX" id="V1U-QE-S3T"/>
+                        <outlet property="panoramaView" destination="C0u-qY-bwX" id="V1U-QE-S3T"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -24,8 +24,7 @@ class ViewController: UIViewController {
     @IBAction func panoramaTypeTapped() {
         if pv.panoramaType == .spherical {
             loadCylindricalImage()
-        }
-        else {
+        } else {
             loadSphericalImage()
         }
     }
@@ -33,8 +32,7 @@ class ViewController: UIViewController {
     @IBAction func motionTypeTapped() {
         if pv.controlMethod == .touch {
             pv.controlMethod = .motion
-        }
-        else {
+        } else {
             pv.controlMethod = .touch
         }
     }

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -12,17 +12,17 @@ import CTPanoramaView
 class ViewController: UIViewController {
 
     @IBOutlet weak var compassView: CTPieSliceView!
-    @IBOutlet weak var pv: CTPanoramaView!
+    @IBOutlet weak var panoramaView: CTPanoramaView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         loadSphericalImage()
-        pv.compass = compassView
+        panoramaView.compass = compassView
     }
 
     @IBAction func panoramaTypeTapped() {
-        if pv.panoramaType == .spherical {
+        if panoramaView.panoramaType == .spherical {
             loadCylindricalImage()
         } else {
             loadSphericalImage()
@@ -30,19 +30,19 @@ class ViewController: UIViewController {
     }
 
     @IBAction func motionTypeTapped() {
-        if pv.controlMethod == .touch {
-            pv.controlMethod = .motion
+        if panoramaView.controlMethod == .touch {
+            panoramaView.controlMethod = .motion
         } else {
-            pv.controlMethod = .touch
+            panoramaView.controlMethod = .touch
         }
     }
 
     func loadSphericalImage() {
-        pv.image = UIImage(named: "spherical")
+        panoramaView.image = UIImage(named: "spherical")
     }
 
     func loadCylindricalImage() {
-        pv.image = UIImage(named: "cylindrical")
+        panoramaView.image = UIImage(named: "cylindrical")
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -13,14 +13,14 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var compassView: CTPieSliceView!
     @IBOutlet weak var pv: CTPanoramaView!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         loadSphericalImage()
         pv.compass = compassView
     }
-    
+
     @IBAction func panoramaTypeTapped() {
         if pv.panoramaType == .spherical {
             loadCylindricalImage()
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
             loadSphericalImage()
         }
     }
-    
+
     @IBAction func motionTypeTapped() {
         if pv.controlMethod == .touch {
             pv.controlMethod = .motion
@@ -38,15 +38,15 @@ class ViewController: UIViewController {
             pv.controlMethod = .touch
         }
     }
-    
+
     func loadSphericalImage() {
         pv.image = UIImage(named: "spherical")
     }
-    
+
     func loadCylindricalImage() {
         pv.image = UIImage(named: "cylindrical")
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .all
     }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -319,9 +319,7 @@ fileprivate extension CMDeviceMotion {
 
             result = SCNVector4(x: -quanternionMultiplier.x, y: -quanternionMultiplier.y, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
 
-        case .unknown:
-            fallthrough
-        case .portrait:
+        case .unknown, .portrait:
             let clockwiseQuanternion = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             let quanternionMultiplier = GLKQuaternionMultiply(clockwiseQuanternion, attitudeQuanternion)
 

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -58,7 +58,7 @@ import ImageIO
     }
 
     @objc public var compass: CTPanoramaCompass?
-    @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> ())?
+    @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> Void)?
 
     // MARK: Private properties
 

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -175,8 +175,7 @@ import ImageIO
             let sphereNode = SCNNode()
             sphereNode.geometry = sphere
             geometryNode = sphereNode
-        }
-        else {
+        } else {
             let tube = SCNTube(innerRadius: radius, outerRadius: radius, height: fovHeight)
             tube.heightSegmentCount = 50
             tube.radialSegmentCount = 300
@@ -205,8 +204,7 @@ import ImageIO
             if motionManager.isDeviceMotionActive {
                 motionManager.stopDeviceMotionUpdates()
             }
-        }
-        else {
+        } else {
             guard motionManager.isDeviceMotionAvailable else {return}
             motionManager.deviceMotionUpdateInterval = 0.015
             motionManager.startDeviceMotionUpdates(using: .xArbitraryZVertical, to: opQueue, withHandler: {[weak self] (motionData, error) in
@@ -226,8 +224,7 @@ import ImageIO
                 DispatchQueue.main.async {
                     if panoramaView.panoramaType == .cylindrical {
                         panoramaView.cameraNode.eulerAngles = SCNVector3Make(0, Float(-userHeading), 0) // Prevent vertical movement in a cylindrical panorama
-                    }
-                    else {
+                    } else {
                         // Use quaternions when in spherical mode to prevent gimbal lock
                         panoramaView.cameraNode.orientation = motionData.orientation()
                     }
@@ -254,8 +251,7 @@ import ImageIO
     @objc private func handlePan(panRec: UIPanGestureRecognizer) {
         if panRec.state == .began {
             prevLocation = CGPoint.zero
-        }
-        else if panRec.state == .changed {
+        } else if panRec.state == .changed {
             var modifiedPanSpeed = panSpeed
 
             if panoramaType == .cylindrical {

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -26,42 +26,42 @@ import ImageIO
 }
 
 @objc public class CTPanoramaView: UIView {
-    
+
     // MARK: Public properties
-    
+
     @objc public var panSpeed = CGPoint(x: 0.005, y: 0.005)
-    
+
     @objc public var image: UIImage? {
         didSet {
             panoramaType = panoramaTypeForCurrentImage
         }
     }
-    
+
     @objc public var overlayView: UIView? {
         didSet {
             replace(overlayView: oldValue, with: overlayView)
         }
     }
-    
+
     @objc public var panoramaType: CTPanoramaType = .cylindrical {
         didSet {
             createGeometryNode()
             resetCameraAngles()
         }
     }
-    
+
     @objc public var controlMethod: CTPanoramaControlMethod = .touch {
         didSet {
             switchControlMethod(to: controlMethod)
             resetCameraAngles()
         }
     }
-    
+
     @objc public var compass: CTPanoramaCompass?
     @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> ())?
-    
+
     // MARK: Private properties
-    
+
     private let radius: CGFloat = 10
     private let sceneView = SCNView()
     private let scene = SCNScene()
@@ -69,28 +69,28 @@ import ImageIO
     private var geometryNode: SCNNode?
     private var prevLocation = CGPoint.zero
     private var prevBounds = CGRect.zero
-    
+
     private lazy var cameraNode: SCNNode = {
         let node = SCNNode()
         let camera = SCNCamera()
         node.camera = camera
         return node
     }()
-    
+
     private lazy var opQueue: OperationQueue = {
         let queue = OperationQueue()
         queue.qualityOfService = .userInitiated
         return queue
     }()
-    
+
     private lazy var fovHeight: CGFloat = {
         return tan(self.yFov/2 * .pi / 180.0) * 2 * self.radius
     }()
-    
+
     private var xFov: CGFloat {
         return yFov * self.bounds.width / self.bounds.height
     }
-    
+
     private var yFov : CGFloat {
         get {
             if #available(iOS 11.0, *) {
@@ -107,7 +107,7 @@ import ImageIO
             }
         }
     }
-    
+
     private var panoramaTypeForCurrentImage: CTPanoramaType {
         if let image = image {
             if image.size.width / image.size.height == 2 {
@@ -116,49 +116,49 @@ import ImageIO
         }
         return .cylindrical
     }
-    
+
     // MARK: Class lifecycle methods
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         commonInit()
     }
-    
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
-    
+
     public convenience init(frame: CGRect, image: UIImage) {
         self.init(frame: frame)
         ({self.image = image})() // Force Swift to call the property observer by calling the setter from a non-init context
     }
-    
+
     deinit {
         if motionManager.isDeviceMotionActive {
             motionManager.stopDeviceMotionUpdates()
         }
     }
-    
+
     private func commonInit() {
         add(view: sceneView)
-    
+
         scene.rootNode.addChildNode(cameraNode)
         yFov = 70
-        
+
         sceneView.scene = scene
         sceneView.backgroundColor = UIColor.black
-        
+
         switchControlMethod(to: controlMethod)
      }
-    
+
     // MARK: Configuration helper methods
 
     private func createGeometryNode() {
         guard let image = image else {return}
-        
+
         geometryNode?.removeFromParentNode()
-        
+
         let material = SCNMaterial()
         material.diffuse.contents = image
         material.diffuse.mipFilter = .nearest
@@ -166,12 +166,12 @@ import ImageIO
         material.diffuse.contentsTransform = SCNMatrix4MakeScale(-1, 1, 1)
         material.diffuse.wrapS = .repeat
         material.cullMode = .front
-        
+
         if panoramaType == .spherical {
             let sphere = SCNSphere(radius: radius)
             sphere.segmentCount = 300
             sphere.firstMaterial = material
-            
+
             let sphereNode = SCNNode()
             sphereNode.geometry = sphere
             geometryNode = sphereNode
@@ -181,27 +181,27 @@ import ImageIO
             tube.heightSegmentCount = 50
             tube.radialSegmentCount = 300
             tube.firstMaterial = material
-            
+
             let tubeNode = SCNNode()
             tubeNode.geometry = tube
             geometryNode = tubeNode
         }
         scene.rootNode.addChildNode(geometryNode!)
     }
-    
+
     private func replace(overlayView: UIView?, with newOverlayView: UIView?) {
         overlayView?.removeFromSuperview()
         guard let newOverlayView = newOverlayView else {return}
         add(view: newOverlayView)
     }
-    
+
     private func switchControlMethod(to method: CTPanoramaControlMethod) {
         sceneView.gestureRecognizers?.removeAll()
 
         if method == .touch {
                 let panGestureRec = UIPanGestureRecognizer(target: self, action: #selector(handlePan(panRec:)))
                 sceneView.addGestureRecognizer(panGestureRec)
- 
+
             if motionManager.isDeviceMotionActive {
                 motionManager.stopDeviceMotionUpdates()
             }
@@ -212,13 +212,13 @@ import ImageIO
             motionManager.startDeviceMotionUpdates(using: .xArbitraryZVertical, to: opQueue, withHandler: {[weak self] (motionData, error) in
                 guard let panoramaView = self else {return}
                 guard panoramaView.controlMethod == .motion else {return}
-                
+
                 guard let motionData = motionData else {
                     print("\(String(describing: error?.localizedDescription))")
                     panoramaView.motionManager.stopDeviceMotionUpdates()
                     return
                 }
-                
+
                 let rm = motionData.attitude.rotationMatrix
                 var userHeading = .pi - atan2(rm.m32, rm.m31)
                 userHeading += .pi/2
@@ -236,49 +236,49 @@ import ImageIO
             })
         }
     }
-    
+
     private func resetCameraAngles() {
         cameraNode.eulerAngles = SCNVector3Make(0, 0, 0)
         self.reportMovement(0, xFov.toRadians(), callHandler: false)
     }
-    
+
     private func reportMovement(_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat, callHandler: Bool = true) {
         compass?.updateUI(rotationAngle: rotationAngle, fieldOfViewAngle: fieldOfViewAngle)
         if callHandler {
             movementHandler?(rotationAngle, fieldOfViewAngle)
         }
     }
-    
+
     // MARK: Gesture handling
-    
+
     @objc private func handlePan(panRec: UIPanGestureRecognizer) {
         if panRec.state == .began {
             prevLocation = CGPoint.zero
         }
         else if panRec.state == .changed {
             var modifiedPanSpeed = panSpeed
-            
+
             if panoramaType == .cylindrical {
                 modifiedPanSpeed.y = 0 // Prevent vertical movement in a cylindrical panorama
             }
-            
+
             let location = panRec.translation(in: sceneView)
             let orientation = cameraNode.eulerAngles
             var newOrientation = SCNVector3Make(orientation.x + Float(location.y - prevLocation.y) * Float(modifiedPanSpeed.y),
                                                 orientation.y + Float(location.x - prevLocation.x) * Float(modifiedPanSpeed.x),
                                                 orientation.z)
-            
+
             if controlMethod == .touch {
                 newOrientation.x = max(min(newOrientation.x, 1.1),-1.1)
             }
 
             cameraNode.eulerAngles = newOrientation
             prevLocation = location
-            
+
             reportMovement(CGFloat(-cameraNode.eulerAngles.y), xFov.toRadians())
         }
     }
-    
+
     public override func layoutSubviews() {
         super.layoutSubviews()
         if bounds.size.width != prevBounds.size.width || bounds.size.height != prevBounds.size.height {
@@ -289,46 +289,46 @@ import ImageIO
 }
 
 fileprivate extension CMDeviceMotion {
-    
+
         func orientation() -> SCNVector4 {
-        
+
         let attitude = self.attitude.quaternion
         let aq = GLKQuaternionMake(Float(attitude.x), Float(attitude.y), Float(attitude.z), Float(attitude.w))
-        
+
         var result: SCNVector4
-        
+
         switch UIApplication.shared.statusBarOrientation {
-            
+
         case .landscapeRight:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(.pi/2, 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             var q = GLKQuaternionMultiply(cq1, aq)
             q = GLKQuaternionMultiply(cq2, q)
-            
+
             result = SCNVector4(x: -q.y, y: q.x, z: q.z, w: q.w)
-            
+
         case .landscapeLeft:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             var q = GLKQuaternionMultiply(cq1, aq)
             q = GLKQuaternionMultiply(cq2, q)
-            
+
             result = SCNVector4(x: q.y, y: -q.x, z: q.z, w: q.w)
-            
+
         case .portraitUpsideDown:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(.pi, 0, 0, 1)
             var q = GLKQuaternionMultiply(cq1, aq)
             q = GLKQuaternionMultiply(cq2, q)
-            
+
             result = SCNVector4(x: -q.x, y: -q.y, z: q.z, w: q.w)
-            
+
         case .unknown:
             fallthrough
         case .portrait:
             let cq = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             let q = GLKQuaternionMultiply(cq, aq)
-            
+
             result = SCNVector4(x: q.x, y: q.y, z: q.z, w: q.w)
         }
         return result
@@ -349,7 +349,7 @@ fileprivate extension FloatingPoint {
     func toDegrees() -> Self {
         return self * 180 / .pi
     }
-    
+
     func toRadians() -> Self {
         return self * .pi / 180
     }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -91,7 +91,7 @@ import ImageIO
         return yFov * self.bounds.width / self.bounds.height
     }
 
-    private var yFov : CGFloat {
+    private var yFov: CGFloat {
         get {
             if #available(iOS 11.0, *) {
                 return cameraNode.camera!.fieldOfView

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -222,15 +222,17 @@ import ImageIO
                 let rm = motionData.attitude.rotationMatrix
                 var userHeading = .pi - atan2(rm.m32, rm.m31)
                 userHeading += .pi/2
-                
-                if panoramaView.panoramaType == .cylindrical {
-                    panoramaView.cameraNode.eulerAngles = SCNVector3Make(0, Float(-userHeading), 0) // Prevent vertical movement in a cylindrical panorama
+
+                DispatchQueue.main.async {
+                    if panoramaView.panoramaType == .cylindrical {
+                        panoramaView.cameraNode.eulerAngles = SCNVector3Make(0, Float(-userHeading), 0) // Prevent vertical movement in a cylindrical panorama
+                    }
+                    else {
+                        // Use quaternions when in spherical mode to prevent gimbal lock
+                        panoramaView.cameraNode.orientation = motionData.orientation()
+                    }
+                    panoramaView.reportMovement(CGFloat(userHeading), panoramaView.xFov.toRadians())
                 }
-                else {
-                    // Use quaternions when in spherical mode to prevent gimbal lock
-                    panoramaView.cameraNode.orientation = motionData.orientation()
-                }
-                panoramaView.reportMovement(CGFloat(userHeading), panoramaView.xFov.toRadians())
             })
         }
     }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -219,8 +219,8 @@ import ImageIO
                     return
                 }
 
-                let rm = motionData.attitude.rotationMatrix
-                var userHeading = .pi - atan2(rm.m32, rm.m31)
+                let rotationMatrix = motionData.attitude.rotationMatrix
+                var userHeading = .pi - atan2(rotationMatrix.m32, rotationMatrix.m31)
                 userHeading += .pi/2
 
                 DispatchQueue.main.async {
@@ -293,7 +293,7 @@ fileprivate extension CMDeviceMotion {
         func orientation() -> SCNVector4 {
 
         let attitude = self.attitude.quaternion
-        let aq = GLKQuaternionMake(Float(attitude.x), Float(attitude.y), Float(attitude.z), Float(attitude.w))
+        let attitudeQuanternion = GLKQuaternionMake(Float(attitude.x), Float(attitude.y), Float(attitude.z), Float(attitude.w))
 
         var result: SCNVector4
 
@@ -302,7 +302,7 @@ fileprivate extension CMDeviceMotion {
         case .landscapeRight:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(.pi/2, 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, attitudeQuanternion)
             quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
             result = SCNVector4(x: -quanternionMultiplier.y, y: quanternionMultiplier.x, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
@@ -310,7 +310,7 @@ fileprivate extension CMDeviceMotion {
         case .landscapeLeft:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, attitudeQuanternion)
             quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
             result = SCNVector4(x: quanternionMultiplier.y, y: -quanternionMultiplier.x, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
@@ -318,7 +318,7 @@ fileprivate extension CMDeviceMotion {
         case .portraitUpsideDown:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(.pi, 0, 0, 1)
-            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, attitudeQuanternion)
             quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
             result = SCNVector4(x: -quanternionMultiplier.x, y: -quanternionMultiplier.y, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
@@ -326,8 +326,8 @@ fileprivate extension CMDeviceMotion {
         case .unknown:
             fallthrough
         case .portrait:
-            let cq = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            let quanternionMultiplier = GLKQuaternionMultiply(cq, aq)
+            let clockwiseQuanternion = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
+            let quanternionMultiplier = GLKQuaternionMultiply(clockwiseQuanternion, attitudeQuanternion)
 
             result = SCNVector4(x: quanternionMultiplier.x, y: quanternionMultiplier.y, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
         }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -94,16 +94,16 @@ import ImageIO
     private var yFov: CGFloat {
         get {
             if #available(iOS 11.0, *) {
-                return cameraNode.camera!.fieldOfView
+                return cameraNode.camera?.fieldOfView ?? 0
             } else {
-                return CGFloat(cameraNode.camera!.yFov)
+                return CGFloat(cameraNode.camera?.yFov ?? 0)
             }
         }
         set {
             if #available(iOS 11.0, *) {
-                cameraNode.camera!.fieldOfView = newValue
+                cameraNode.camera?.fieldOfView = newValue
             } else {
-                cameraNode.camera!.yFov = Double(newValue)
+                cameraNode.camera?.yFov = Double(newValue)
             }
         }
     }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -289,7 +289,7 @@ import ImageIO
 
 fileprivate extension CMDeviceMotion {
 
-        func orientation() -> SCNVector4 {
+    func orientation() -> SCNVector4 {
 
         let attitude = self.attitude.quaternion
         let attitudeQuanternion = GLKQuaternion(quanternion: attitude)

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -132,7 +132,7 @@ import ImageIO
     public convenience init(frame: CGRect, image: UIImage) {
         self.init(frame: frame)
         // Force Swift to call the property observer by calling the setter from a non-init context
-        ({self.image = image})()
+        ({ self.image = image })()
     }
 
     deinit {

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -302,34 +302,34 @@ fileprivate extension CMDeviceMotion {
         case .landscapeRight:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(.pi/2, 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            var q = GLKQuaternionMultiply(cq1, aq)
-            q = GLKQuaternionMultiply(cq2, q)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
-            result = SCNVector4(x: -q.y, y: q.x, z: q.z, w: q.w)
+            result = SCNVector4(x: -quanternionMultiplier.y, y: quanternionMultiplier.x, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
 
         case .landscapeLeft:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 0, 1, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            var q = GLKQuaternionMultiply(cq1, aq)
-            q = GLKQuaternionMultiply(cq2, q)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
-            result = SCNVector4(x: q.y, y: -q.x, z: q.z, w: q.w)
+            result = SCNVector4(x: quanternionMultiplier.y, y: -quanternionMultiplier.x, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
 
         case .portraitUpsideDown:
             let cq1 = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
             let cq2 = GLKQuaternionMakeWithAngleAndAxis(.pi, 0, 0, 1)
-            var q = GLKQuaternionMultiply(cq1, aq)
-            q = GLKQuaternionMultiply(cq2, q)
+            var quanternionMultiplier = GLKQuaternionMultiply(cq1, aq)
+            quanternionMultiplier = GLKQuaternionMultiply(cq2, quanternionMultiplier)
 
-            result = SCNVector4(x: -q.x, y: -q.y, z: q.z, w: q.w)
+            result = SCNVector4(x: -quanternionMultiplier.x, y: -quanternionMultiplier.y, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
 
         case .unknown:
             fallthrough
         case .portrait:
             let cq = GLKQuaternionMakeWithAngleAndAxis(-(.pi/2), 1, 0, 0)
-            let q = GLKQuaternionMultiply(cq, aq)
+            let quanternionMultiplier = GLKQuaternionMultiply(cq, aq)
 
-            result = SCNVector4(x: q.x, y: q.y, z: q.z, w: q.w)
+            result = SCNVector4(x: quanternionMultiplier.x, y: quanternionMultiplier.y, z: quanternionMultiplier.z, w: quanternionMultiplier.w)
         }
         return result
     }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -265,7 +265,7 @@ import ImageIO
                                                 orientation.z)
 
             if controlMethod == .touch {
-                newOrientation.x = max(min(newOrientation.x, 1.1),-1.1)
+                newOrientation.x = max(min(newOrientation.x, 1.1), -1.1)
             }
 
             cameraNode.eulerAngles = newOrientation

--- a/Source/CTPieSliceView.swift
+++ b/Source/CTPieSliceView.swift
@@ -9,64 +9,64 @@
 import UIKit
 
 @IBDesignable @objcMembers public class CTPieSliceView: UIView {
-    
+
     @IBInspectable var sliceAngle: CGFloat = .pi/2 {
         didSet { setNeedsDisplay() }
     }
-    
+
     @IBInspectable var sliceColor: UIColor = .red {
         didSet { setNeedsDisplay() }
     }
-    
+
     @IBInspectable var outerRingColor: UIColor = .green {
         didSet { setNeedsDisplay() }
     }
-    
+
     @IBInspectable var bgColor: UIColor = .black {
         didSet { setNeedsDisplay() }
     }
-    
+
     #if !TARGET_INTERFACE_BUILDER
-    
+
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         commonInit()
     }
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
     }
-    
+
     #endif
-    
+
     func commonInit() {
         backgroundColor = UIColor.clear
         contentMode = .redraw
     }
-    
+
     public override func draw(_ rect: CGRect) {
         super.draw(rect)
-        
+
         guard let ctx = UIGraphicsGetCurrentContext() else {return}
-        
+
         // Draw the background
         ctx.addEllipse(in: bounds)
         ctx.setFillColor(bgColor.cgColor)
         ctx.fillPath()
-        
+
         // Draw the outer ring
         ctx.addEllipse(in: bounds.insetBy(dx: 2, dy: 2))
         ctx.setStrokeColor(outerRingColor.cgColor)
         ctx.setLineWidth(2)
         ctx.strokePath()
-        
+
         let radius = (bounds.width/2)-6
         let localCenter = CGPoint(x: bounds.size.width/2, y: bounds.size.height/2)
         let startAngle = -(.pi/2 + sliceAngle/2)
         let endAngle = startAngle + sliceAngle
         let arcStartPoint = CGPoint(x: localCenter.x + radius*cos(startAngle), y: localCenter.y + radius*sin(startAngle))
-        
+
         // Draw the inner slice
         ctx.beginPath()
         ctx.move(to: localCenter)

--- a/Source/CTPieSliceView.swift
+++ b/Source/CTPieSliceView.swift
@@ -65,7 +65,8 @@ import UIKit
         let localCenter = CGPoint(x: bounds.size.width/2, y: bounds.size.height/2)
         let startAngle = -(.pi/2 + sliceAngle/2)
         let endAngle = startAngle + sliceAngle
-        let arcStartPoint = CGPoint(x: localCenter.x + radius*cos(startAngle), y: localCenter.y + radius*sin(startAngle))
+        let arcStartPoint = CGPoint(x: localCenter.x + radius * cos(startAngle),
+                                    y: localCenter.y + radius * sin(startAngle))
 
         // Draw the inner slice
         ctx.beginPath()

--- a/Tests/CTPanoramaViewTests.swift
+++ b/Tests/CTPanoramaViewTests.swift
@@ -51,7 +51,7 @@ class CTPanoramaViewTests: XCTestCase {
         XCTAssert(overlayView.superview == nil)
         XCTAssert(anotherOverlayView.superview == panoramaView)
 
-        panoramaView.overlayView = nil;
+        panoramaView.overlayView = nil
         XCTAssert(overlayView.superview == nil)
     }
 

--- a/Tests/CTPanoramaViewTests.swift
+++ b/Tests/CTPanoramaViewTests.swift
@@ -13,52 +13,52 @@ class CTPanoramaViewTests: XCTestCase {
 
     private var sphericalImage: UIImage!
     private var cylindricalImage: UIImage!
-    
+
     override func setUp() {
         super.setUp()
         sphericalImage = createImage(size: CGSize(width: 100, height: 50))
         cylindricalImage = createImage(size: CGSize(width: 200, height: 50))
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testThatPanoramaTypeChangesAccordingToImage() {
         var pv = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
         XCTAssert(pv.panoramaType == .spherical)
-        
+
         pv = CTPanoramaView(frame: CGRect.zero, image: cylindricalImage)
         XCTAssert(pv.panoramaType == .cylindrical)
-        
+
         pv.image = sphericalImage
         XCTAssert(pv.panoramaType == .spherical)
-        
+
         pv.image = cylindricalImage
         XCTAssert(pv.panoramaType == .cylindrical)
     }
-    
+
     func testThatSettingOverlayViewAddsTheViewOnTop() {
         let pv = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
         let overlayView = UIView()
-        
+
         pv.overlayView = overlayView
         XCTAssert(overlayView.superview == pv)
-        
+
         let anotherOverlayView = UIView()
-        
+
         pv.overlayView = anotherOverlayView
         XCTAssert(overlayView.superview == nil)
         XCTAssert(anotherOverlayView.superview == pv)
-        
+
         pv.overlayView = nil;
         XCTAssert(overlayView.superview == nil)
     }
-    
+
     func createImage(size: CGSize, scale: CGFloat = 1, orientation: UIImageOrientation = .up) -> UIImage {
         UIGraphicsBeginImageContextWithOptions(size, true, scale)
         defer {UIGraphicsEndImageContext()}
-        
+
         let image = UIGraphicsGetImageFromCurrentImageContext()
         return UIImage(cgImage: (image?.cgImage)!, scale: scale, orientation: orientation)
     }

--- a/Tests/CTPanoramaViewTests.swift
+++ b/Tests/CTPanoramaViewTests.swift
@@ -25,33 +25,33 @@ class CTPanoramaViewTests: XCTestCase {
     }
 
     func testThatPanoramaTypeChangesAccordingToImage() {
-        var pv = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
-        XCTAssert(pv.panoramaType == .spherical)
+        var panoramaView = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
+        XCTAssert(panoramaView.panoramaType == .spherical)
 
-        pv = CTPanoramaView(frame: CGRect.zero, image: cylindricalImage)
-        XCTAssert(pv.panoramaType == .cylindrical)
+        panoramaView = CTPanoramaView(frame: CGRect.zero, image: cylindricalImage)
+        XCTAssert(panoramaView.panoramaType == .cylindrical)
 
-        pv.image = sphericalImage
-        XCTAssert(pv.panoramaType == .spherical)
+        panoramaView.image = sphericalImage
+        XCTAssert(panoramaView.panoramaType == .spherical)
 
-        pv.image = cylindricalImage
-        XCTAssert(pv.panoramaType == .cylindrical)
+        panoramaView.image = cylindricalImage
+        XCTAssert(panoramaView.panoramaType == .cylindrical)
     }
 
     func testThatSettingOverlayViewAddsTheViewOnTop() {
-        let pv = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
+        let panoramaView = CTPanoramaView(frame: CGRect.zero, image: sphericalImage)
         let overlayView = UIView()
 
-        pv.overlayView = overlayView
-        XCTAssert(overlayView.superview == pv)
+        panoramaView.overlayView = overlayView
+        XCTAssert(overlayView.superview == panoramaView)
 
         let anotherOverlayView = UIView()
 
-        pv.overlayView = anotherOverlayView
+        panoramaView.overlayView = anotherOverlayView
         XCTAssert(overlayView.superview == nil)
-        XCTAssert(anotherOverlayView.superview == pv)
+        XCTAssert(anotherOverlayView.superview == panoramaView)
 
-        pv.overlayView = nil;
+        panoramaView.overlayView = nil;
         XCTAssert(overlayView.superview == nil)
     }
 


### PR DESCRIPTION
- Added [swiftlint](https://github.com/realm/SwiftLint) build phase to example and CTPanoramaView projects
- Removed all warnings from swiftlint
- Replaced force unwrap code with nil coalescing operator

Also depends on #21.
Maybe, it would be better to add [Danger-swift](https://github.com/danger/danger-swift) instead of linting on each build. I can make a separate PR if you want.