### PR TITLE
Control both

### DIFF
--- a/CTPanoramaView.podspec
+++ b/CTPanoramaView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CTPanoramaView"
-  s.version          = "1.3"
+  s.version          = "1.4"
   s.summary          = "Displays spherical or cylindrical panoramas and 360 photos with touch or motion based controls."
   s.homepage         = "https://github.com/scihant/CTPanoramaView"
   s.screenshots      = "https://cloud.githubusercontent.com/assets/3991481/23154113/ce5aa6b8-f814-11e6-9c97-4d91629733f8.gif", "https://cloud.githubusercontent.com/assets/3991481/23154919/d5f98476-f818-11e6-8c71-22011a027d96.jpg"

--- a/CTPanoramaView.podspec
+++ b/CTPanoramaView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CTPanoramaView"
-  s.version          = "1.4"
+  s.version          = "1.5"
   s.summary          = "Displays spherical or cylindrical panoramas and 360 photos with touch or motion based controls."
   s.homepage         = "https://github.com/scihant/CTPanoramaView"
   s.screenshots      = "https://cloud.githubusercontent.com/assets/3991481/23154113/ce5aa6b8-f814-11e6-9c97-4d91629733f8.gif", "https://cloud.githubusercontent.com/assets/3991481/23154919/d5f98476-f818-11e6-8c71-22011a027d96.jpg"

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -34,7 +34,7 @@ import ImageIO
     @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> Void)?
 
     // slow down pan rotation
-    @objc public var panSpeed = CGPoint(x: 0.5, y: 0.5)
+    @objc public var panSpeed = CGPoint(x: 0.4, y: 0.4)
     @objc public var startAngle: Float = 0
 
     @objc public var image: UIImage? {

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -419,6 +419,11 @@ import ImageIO
     }
 
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+
+        // do not mix pan gestures with the others
+        if(gestureRecognizer is UIPanGestureRecognizer) || (otherGestureRecognizer is UIPanGestureRecognizer){
+            return false;
+        }
         return true
     }
 }

--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -352,7 +352,7 @@ import ImageIO
             startScale = cameraNode.camera!.yFov
         case .changed:
             let fov = startScale / zoom
-            if fov > 20 && fov < 80 {
+            if fov > 20 && fov <= 100 {
                 cameraNode.camera!.yFov = fov
             }
         default:


### PR DESCRIPTION
This PR is related to https://github.com/scihant/CTPanoramaView/issues/46 

After hours of testing, I wasn't able to combine both finger and motion rotation values. However, I think this approach can be useful for some (e.g., https://github.com/lightbasenl/react-native-panorama-view). Basically, this new `both` option starts with motion rotation, but switches to finger rotation if it is used.