### PR TITLE
Allow the image to be rotated independent of the camera

### DIFF
--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -33,6 +33,12 @@ import ImageIO
     @objc public var movementHandler: ((_ rotationAngle: CGFloat, _ fieldOfViewAngle: CGFloat) -> Void)?
     @objc public var panSpeed = CGPoint(x: 0.005, y: 0.005)
     @objc public var startAngle: Float = 0
+    
+    @objc public var angleOffset: Float = 0 {
+        didSet {
+            geometryNode?.rotation = SCNQuaternion(0, 1, 0, angleOffset)
+        }
+    }
 
     @objc public var minFoV: CGFloat = 20
     @objc public var maxFoV: CGFloat = 80
@@ -197,6 +203,7 @@ import ImageIO
             tubeNode.geometry = tube
             geometryNode = tubeNode
         }
+        geometryNode?.rotation = SCNQuaternion(0, 1, 0, angleOffset)
         scene.rootNode.addChildNode(geometryNode!)
     }
 


### PR DESCRIPTION
This would provide a method for rotating the image rather than the camera. 

The benefit of doing this rather than the existing `startAngle` property is that it works the same regardless of camera control method or panorama type. 

The main difference is that it doesn't change the orientation of the direction indicator. In my projects case, that's a benefit since we are applying a rotation correct for the fact that images start facing backwards using this library