### PR TITLE
Binding sceneView.backgroundColor with self.backgroundColor

### DIFF
--- a/Source/CTPanoramaView.swift
+++ b/Source/CTPanoramaView.swift
@@ -67,6 +67,14 @@ import ImageIO
             resetCameraAngles()
         }
     }
+    
+    // MARK: Overriding
+    
+    public override var backgroundColor: UIColor? {
+        didSet {
+            sceneView.backgroundColor = backgroundColor
+        }
+    }
 
     // MARK: Private properties
 


### PR DESCRIPTION
Background color is set at initialization. If you initialize the view through xib, then it works fine. But if you create a view programmatically, then it is impossible to set the color during initialization, only after. But if set after, then sceneView will not update its background color